### PR TITLE
Eliminate OwnedBlock and BorrowedBlock

### DIFF
--- a/examples/cache.rs
+++ b/examples/cache.rs
@@ -1,6 +1,6 @@
 use ipfs_sqlite_block_store::{
     cache::{AsyncCacheTracker, Spawner, SqliteCacheTracker},
-    Block, BlockStore, Config, OwnedBlock, SizeTargets,
+    BlockStore, Config, SizeTargets,
 };
 use itertools::*;
 use libipld::{cbor::DagCborCodec, codec::Codec, Cid, DagCbor};
@@ -8,6 +8,8 @@ use multihash::{Code, MultihashDigest};
 use std::time::Instant;
 use tracing::*;
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+
+type Block = libipld::Block<libipld::DefaultParams>;
 
 #[derive(Debug, DagCbor)]
 struct Node {
@@ -25,7 +27,7 @@ impl Node {
 }
 
 /// creates a block with a min size
-fn sized(name: &str, min_size: usize) -> OwnedBlock {
+fn sized(name: &str, min_size: usize) -> Block {
     let mut text = name.to_string();
     while text.len() < min_size {
         text += " ";
@@ -34,11 +36,11 @@ fn sized(name: &str, min_size: usize) -> OwnedBlock {
     let bytes = DagCborCodec.encode(&ipld).unwrap();
     let hash = Code::Sha2_256.digest(&bytes);
     // https://github.com/multiformats/multicodec/blob/master/table.csv
-    OwnedBlock::new(Cid::new_v1(0x71, hash), bytes)
+    Block::new_unchecked(Cid::new_v1(0x71, hash), bytes)
 }
 
 /// creates a block with the name "unpinned-<i>" and a size of 1000
-fn unpinned(i: usize) -> OwnedBlock {
+fn unpinned(i: usize) -> Block {
     sized(&format!("{}", i), 10000 - 16)
 }
 

--- a/examples/import.rs
+++ b/examples/import.rs
@@ -1,4 +1,4 @@
-use ipfs_sqlite_block_store::{BlockStore, Config, OwnedBlock};
+use ipfs_sqlite_block_store::{BlockStore, Config};
 use itertools::*;
 use libipld::cid::Cid;
 use libipld::store::DefaultParams;
@@ -7,6 +7,7 @@ use std::convert::TryFrom;
 use std::path::Path;
 use tracing::*;
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+type Block = libipld::Block<libipld::DefaultParams>;
 
 pub fn query_roots(path: &Path) -> anyhow::Result<Vec<(String, Cid)>> {
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
@@ -81,7 +82,7 @@ fn main() -> anyhow::Result<()> {
             //println!("{} {} {}", cid, block.pinned, block.data.len());
             let block = libipld::Block::<DefaultParams>::new(cid, block.data)?;
             let (cid, data) = block.into_inner();
-            Ok(OwnedBlock::new(cid, data))
+            Block::new(cid, data)
         })
     });
 


### PR DESCRIPTION
We are now more tightly integrated with libipld than initially, so we can just use libipld::Block directly as a replacement for OwnedBlock. BorrowedBlock can be just a ref.

This is the first in a series of PRs for 0.5.0