### PR TITLE
remove exposed connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,14 +711,4 @@ impl BlockStore {
     pub fn get_block(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
         Ok(self.get_blocks(std::iter::once(*cid))?.next().unwrap().1)
     }
-
-    /// the underlying rusqlite connection
-    pub fn connection(&self) -> &Connection {
-        &self.conn
-    }
-
-    /// the underlying rusqlite connection as a mutable reference
-    pub fn connection_mut(&mut self) -> &mut Connection {
-        &mut self.conn
-    }
 }


### PR DESCRIPTION
I thought this would be a good idea to realize the dream of having everything in one database at actyx. But since we have decided to have two databases, this is no longer needed. And it is probably a good idea to leave this out until somebody has a real pressing need for it.