### PR TITLE
Make get_block and put_block on transaction mutable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,7 +466,7 @@ where
         blocks: impl IntoIterator<Item = Block<S>>,
         pin: Option<&TempPin>,
     ) -> Result<()> {
-        let txn = self.transaction()?;
+        let mut txn = self.transaction()?;
         for block in blocks {
             txn.put_block(&block, pin)?;
         }
@@ -483,7 +483,7 @@ where
     /// - `links` links extracted from the data
     /// - `alias` an optional temporary alias
     pub fn put_block(&mut self, block: &Block<S>, pin: Option<&TempPin>) -> Result<()> {
-        let txn = self.transaction()?;
+        let mut txn = self.transaction()?;
         txn.put_block(block, pin)?;
         txn.commit()
     }


### PR DESCRIPTION
That way we don't have to have a mutex for the mutable TransactionInfo

We still need the TransactionInfo due to some drop shenanigans.