### PR TITLE
ignore incremental_vacuum result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,7 +571,7 @@ where
             let result = in_txn(&mut self.conn, move |txn| {
                 Ok(incremental_delete_orphaned(txn, min_blocks, max_duration)?)
             })?;
-            self.conn.execute("PRAGMA incremental_vacuum;", [])?;
+            self.conn.execute("PRAGMA incremental_vacuum;", []).ok();
             Ok(result)
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,7 +542,7 @@ where
                 for id in expired_temp_pins {
                     delete_temp_pin(txn, id)?;
                 }
-                incremental_gc(&txn, min_blocks, max_duration, size_targets, cache_tracker)
+                incremental_gc(txn, min_blocks, max_duration, size_targets, cache_tracker)
             })
         })?;
         self.config.cache_tracker.blocks_deleted(deleted);
@@ -571,6 +571,8 @@ where
             let result = in_txn(&mut self.conn, move |txn| {
                 Ok(incremental_delete_orphaned(txn, min_blocks, max_duration)?)
             })?;
+            // in tests this doesn’t return results, but in Actyx it raises ExecuteReturnedResults
+            // so we just ignore the outcome
             self.conn.execute("PRAGMA incremental_vacuum;", []).ok();
             Ok(result)
         })

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -216,7 +216,7 @@ fn size_targets() -> anyhow::Result<()> {
     for i in 0..2 {
         let block = pinned(i);
         store.put_block(&block, None)?;
-        store.alias(block.cid().to_bytes(), Some(&block.cid()))?;
+        store.alias(block.cid().to_bytes(), Some(block.cid()))?;
     }
 
     // add data that is within the size targets
@@ -303,7 +303,7 @@ fn cache_test(tracker: impl CacheTracker + 'static) -> anyhow::Result<()> {
 
     // access one of the existing unpinned blocks to move it to the front
     assert_eq!(
-        store.get_block(&unpinned(0).cid())?,
+        store.get_block(unpinned(0).cid())?,
         Some(unpinned(0).data().to_vec())
     );
 


### PR DESCRIPTION
It seems that `PRAGMA incremental_vacuum` sometimes returns a result, which trips up `conn.execute()` (which I consider a dubious choice, to put it mildly).

fixes #46
